### PR TITLE
also allow Gravity.START and Gravity.END for newer sdk versions

### DIFF
--- a/expectanim/src/main/java/com/github/florent37/expectanim/core/Expectations.java
+++ b/expectanim/src/main/java/com/github/florent37/expectanim/core/Expectations.java
@@ -135,7 +135,7 @@ public class Expectations {
         return new PositionAnimExpectationAlignRight(otherView);
     }
 
-    @IntDef(value = {Gravity.LEFT, Gravity.RIGHT, Gravity.TOP, Gravity.BOTTOM})
+    @IntDef(value = {Gravity.LEFT, Gravity.RIGHT, Gravity.END, Gravity.START, Gravity.TOP, Gravity.BOTTOM})
     @interface GravityIntDef {
     }
 
@@ -147,7 +147,7 @@ public class Expectations {
         return new AlphaAnimExpectationValue(alpha);
     }
 
-    public static AlphaAnimExpectation sameAlphaAs(View otherView){
+    public static AlphaAnimExpectation sameAlphaAs(View otherView) {
         return new AlphaAnimExpectationValue(otherView.getAlpha());
     }
 
@@ -167,7 +167,7 @@ public class Expectations {
     public @interface GravityScaleVerticalIntDef {
     }
 
-    @IntDef(value = {Gravity.LEFT, Gravity.RIGHT, Gravity.CENTER, Gravity.CENTER_HORIZONTAL})
+    @IntDef(value = {Gravity.LEFT, Gravity.RIGHT, Gravity.END, Gravity.START, Gravity.CENTER, Gravity.CENTER_HORIZONTAL})
     public @interface GravityScaleHorizontalIntDef {
     }
 
@@ -176,11 +176,11 @@ public class Expectations {
     }
 
     public static ScaleAnimExpectation scale(float scaleX, float scaleY, @GravityScaleHorizontalIntDef int gravityHorizontal, @GravityScaleVerticalIntDef int gravityVertical) {
-        return new ScaleAnimExpectationValues(scaleX, scaleY,  gravityHorizontal, gravityVertical);
+        return new ScaleAnimExpectationValues(scaleX, scaleY, gravityHorizontal, gravityVertical);
     }
 
     public static ScaleAnimExpectation scale(float scaleX, float scaleY) {
-        return new ScaleAnimExpectationValues(scaleX, scaleY,  null, null);
+        return new ScaleAnimExpectationValues(scaleX, scaleY, null, null);
     }
 
     public static ScaleAnimExpectation height(int height, @GravityScaleHorizontalIntDef int gravityHorizontal, @GravityScaleVerticalIntDef int gravityVertical) {
@@ -210,7 +210,7 @@ public class Expectations {
     public static ScaleAnimExpectation sameHeightAs(View otherView) {
         return new ScaleAnimExpectationSameHeightAs(otherView, null, null);
     }
-    
+
     //endregion
 
     //region custom
@@ -233,7 +233,7 @@ public class Expectations {
     }
 
     public static RotationExpectation vertical(boolean bottomOfViewAtLeft) {
-        if(bottomOfViewAtLeft) {
+        if (bottomOfViewAtLeft) {
             return new RotationExpectationValue(90);
         } else {
             return new RotationExpectationValue(270);

--- a/expectanim/src/main/java/com/github/florent37/expectanim/core/scale/ExpectAnimScaleManager.java
+++ b/expectanim/src/main/java/com/github/florent37/expectanim/core/scale/ExpectAnimScaleManager.java
@@ -54,8 +54,14 @@ public class ExpectAnimScaleManager {
                 final Integer gravityHorizontal = expectation.getGravityHorizontal();
                 if (gravityHorizontal != null) {
                     switch (gravityHorizontal){
-                        case Gravity.LEFT : pivotX = (float)viewToMove.getLeft(); break;
-                        case Gravity.RIGHT : pivotX = (float)viewToMove.getRight(); break;
+                        case Gravity.LEFT:
+                        case Gravity.START:
+                            pivotX = (float)viewToMove.getLeft();
+                            break;
+                        case Gravity.RIGHT:
+                        case Gravity.END:
+                            pivotX = (float)viewToMove.getRight();
+                            break;
                         case Gravity.CENTER_HORIZONTAL:
                         case Gravity.CENTER : pivotX = viewToMove.getLeft() + viewToMove.getWidth()/2f; break;
                     }


### PR DESCRIPTION
I've added Gravity.START and Gravity.END to the "GravityIntDef" Interface to also allow the using of these Gravity values in the IDE. Since Android Studio constantly begs for also using START, END instead of LEFT, RIGHT (since it also allows for arabic countries) this would be highly convenient.

Please retest the functionality.